### PR TITLE
Alternate matrix products for speed improvments

### DIFF
--- a/TcTransform/TcTransform/POUs/Functions/HMatrix_Product.TcPOU
+++ b/TcTransform/TcTransform/POUs/Functions/HMatrix_Product.TcPOU
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="HMatrix_Product" Id="{afc324f5-d5f2-0393-3f8c-2ac4344d88f9}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION HMatrix_Product
+VAR_IN_OUT CONSTANT
+    A : HMatrix;
+    B : HMatrix;
+END_VAR
+VAR_IN_OUT
+    Res : HMatrix;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[// Complexity : 36M+36A
+// Rotation = A.Rot * B.rot
+Res.SetI(0,  A.Data[0]*B.Data[0]+A.Data[1]*B.Data[4]+A.Data[2]*B.Data[8]);
+Res.SetI(1,  A.Data[0]*B.Data[1]+A.Data[1]*B.Data[5]+A.Data[2]*B.Data[9]);
+Res.SetI(2,  A.Data[0]*B.Data[2]+A.Data[1]*B.Data[6]+A.Data[2]*B.Data[10]);
+Res.SetI(4,  A.Data[4]*B.Data[0]+A.Data[5]*B.Data[4]+A.Data[6]*B.Data[8]);
+Res.SetI(5,  A.Data[4]*B.Data[1]+A.Data[5]*B.Data[5]+A.Data[6]*B.Data[9]);
+Res.SetI(6,  A.Data[4]*B.Data[2]+A.Data[5]*B.Data[6]+A.Data[6]*B.Data[10]);
+Res.SetI(8,  A.Data[8]*B.Data[0]+A.Data[9]*B.Data[4]+A.Data[10]*B.Data[8]);
+Res.SetI(9,  A.Data[8]*B.Data[1]+A.Data[9]*B.Data[5]+A.Data[10]*B.Data[9]);
+Res.SetI(10, A.Data[8]*B.Data[2]+A.Data[9]*B.Data[6]+A.Data[10]*B.Data[10]);
+
+// Position = A.Rot*B.Pos+A.Pos
+Res.SetI(3,  A.Data[0]*B.Data[3] + A.Data[1]*B.Data[7] + A.Data[2]*B.Data[11]    + A.Data[3]);
+Res.SetI(7,  A.Data[4]*B.Data[3] + A.Data[5]*B.Data[7] + A.Data[6]*B.Data[11]    + A.Data[7]);
+Res.SetI(11, A.Data[8]*B.Data[3] + A.Data[9]*B.Data[7] + A.Data[10]*B.Data[11]   + A.Data[11]);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/TcTransform/TcTransform/POUs/Functions/RMatrix_Product.TcPOU
+++ b/TcTransform/TcTransform/POUs/Functions/RMatrix_Product.TcPOU
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="RMatrix_Product" Id="{e024edc4-b37a-07c3-3ffa-910bcca1ff49}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION RMatrix_Product
+VAR_IN_OUT CONSTANT
+    A : RMatrix;
+    B : RMatrix;
+END_VAR
+VAR_IN_OUT
+    Res : RMatrix;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[// Complexity : 27M+27A
+Res.SetI(0, A.Data[0]*B.Data[0]+A.Data[1]*B.Data[3]+A.Data[2]*B.Data[6]);
+Res.SetI(1, A.Data[0]*B.Data[1]+A.Data[1]*B.Data[4]+A.Data[2]*B.Data[7]);
+Res.SetI(2, A.Data[0]*B.Data[2]+A.Data[1]*B.Data[5]+A.Data[2]*B.Data[8]);
+Res.SetI(3, A.Data[3]*B.Data[0]+A.Data[4]*B.Data[3]+A.Data[5]*B.Data[6]);
+Res.SetI(4, A.Data[3]*B.Data[1]+A.Data[4]*B.Data[4]+A.Data[5]*B.Data[7]);
+Res.SetI(5, A.Data[3]*B.Data[2]+A.Data[4]*B.Data[5]+A.Data[5]*B.Data[8]);
+Res.SetI(6, A.Data[6]*B.Data[0]+A.Data[7]*B.Data[3]+A.Data[8]*B.Data[6]);
+Res.SetI(7, A.Data[6]*B.Data[1]+A.Data[7]*B.Data[4]+A.Data[8]*B.Data[7]);
+Res.SetI(8, A.Data[6]*B.Data[2]+A.Data[7]*B.Data[5]+A.Data[8]*B.Data[8]);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/TcTransform/TcTransform/POUs/Functions/RMatrix_Vector3_Product.TcPOU
+++ b/TcTransform/TcTransform/POUs/Functions/RMatrix_Vector3_Product.TcPOU
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="RMatrix_Vector3_Product" Id="{d36bb23c-9ca8-0a0d-0050-acea719bb1a0}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION RMatrix_Vector3_Product
+VAR_IN_OUT CONSTANT
+    A : RMatrix;
+    B : Vector3;
+END_VAR
+VAR_IN_OUT
+    Res : Vector3;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[// Complexity : 9M+6A
+Res.SetI(0, A.Data[0]*B.Data[0] + A.Data[1]*B.Data[1] + A.Data[2]*B.Data[2]);
+Res.SetI(1, A.Data[3]*B.Data[0] + A.Data[4]*B.Data[1] + A.Data[5]*B.Data[2]);
+Res.SetI(2, A.Data[6]*B.Data[0] + A.Data[7]*B.Data[1] + A.Data[8]*B.Data[2]);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/TcTransform/TcTransform/POUs/Functions/Vector3_CrossProduct.TcPOU
+++ b/TcTransform/TcTransform/POUs/Functions/Vector3_CrossProduct.TcPOU
@@ -14,9 +14,9 @@ VAR_IN_OUT
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Complexity : 6M+3A
-Res.SetI(0, A.GetI(1)*B.GetI(2) - A.GetI(2)*B.GetI(1));
-Res.SetI(1, A.GetI(2)*B.GetI(0) - A.GetI(0)*B.GetI(2));
-Res.SetI(2, A.GetI(0)*B.GetI(1) - A.GetI(1)*B.GetI(0));]]></ST>
+Res.SetI(0, A.Data[1]*B.Data[2] - A.Data[2]*B.Data[1]);
+Res.SetI(1, A.Data[2]*B.Data[0] - A.Data[0]*B.Data[2]);
+Res.SetI(2, A.Data[0]*B.Data[1] - A.Data[1]*B.Data[0]);]]></ST>
     </Implementation>
     <LineIds Name="Vector3_CrossProduct">
       <LineId Id="30" Count="2" />

--- a/TcTransform/TcTransform/TcTransform.plcproj
+++ b/TcTransform/TcTransform/TcTransform.plcproj
@@ -103,6 +103,9 @@
     <Compile Include="POUs\Functions\RMatrix_Product.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Functions\RMatrix_Vector3_Product.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Functions\Vector3_CrossProduct.TcPOU">
       <SubType>Code</SubType>
     </Compile>

--- a/TcTransform/TcTransform/TcTransform.plcproj
+++ b/TcTransform/TcTransform/TcTransform.plcproj
@@ -100,6 +100,9 @@
     <Compile Include="POUs\ATAN2.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Functions\RMatrix_Product.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Functions\Vector3_CrossProduct.TcPOU">
       <SubType>Code</SubType>
     </Compile>

--- a/TcTransform/TcTransform/TcTransform.plcproj
+++ b/TcTransform/TcTransform/TcTransform.plcproj
@@ -100,6 +100,9 @@
     <Compile Include="POUs\ATAN2.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Functions\HMatrix_Product.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Functions\RMatrix_Product.TcPOU">
       <SubType>Code</SubType>
     </Compile>

--- a/TcTransformTest/TcTransformTest/TESTs/FB_HMatrix_Test.TcPOU
+++ b/TcTransformTest/TcTransformTest/TESTs/FB_HMatrix_Test.TcPOU
@@ -13,7 +13,8 @@ END_VAR
       <ST><![CDATA[WhenSetFromComponentsExpectValuesRetained();
 WhenTransformedByIdentityExpectSame();
 WhenVectorTransformedExpectResult();
-WhenMatrixTransformedExpectResult();]]></ST>
+WhenMatrixTransformedExpectResult();
+WhenPostMultipliedByHMatrixExpectResult();]]></ST>
     </Implementation>
     <Method Name="WhenMatrixTransformedExpectResult" Id="{b9562da0-add4-4fb7-aadc-2b99f713b825}">
       <Declaration><![CDATA[METHOD PRIVATE WhenMatrixTransformedExpectResult
@@ -48,6 +49,69 @@ V4.SetFromComponents(0,0,-1);
 AssertTrue(V3.IsNearlyEqual(V4,1E-6),'Result is not correct');
 
 TEST_FINISHED();]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="WhenPostMultipliedByHMatrixExpectResult" Id="{a46c62cc-74f9-0a7e-1db0-1dd23ea57a7f}">
+      <Declaration><![CDATA[METHOD WhenPostMultipliedByHMatrixExpectResult
+VAR_INPUT
+END_VAR
+VAR
+	H1 : HMatrix;
+	H2 : HMatrix;
+    H3 : HMatrix;
+
+    R1 : RMatrix;
+    R2 : RMatrix;
+
+    V1 : Vector3;
+    V2 : Vector3;
+
+    Delta : LREAL := 1E-09;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('WhenPostMultipliedByHMatrixExpectResult');
+
+// @TEST-RUN
+R1.SetFromAngle(-PI/3,0);
+R1.SetFromAngle( PI/5,1);
+R1.SetFromAngle(-PI/6,2);
+V1.SetI(0, -3);
+V1.SetI(1, 7.5);
+V1.SetI(2, -0.6);
+
+R2.SetFromAngle(PI/7,0);
+R2.SetFromAngle(-PI/3,1);
+R2.SetFromAngle(PI/5,2);
+V2.SetI(0, 15.1);
+V2.SetI(1, -0.34);
+V2.SetI(2, 5.75);
+
+H1.SetFromComponents(R1, V1);
+H2.SetFromComponents(R2, V2);
+
+HMatrix_Product(H1, H2, H3);
+
+// @TEST-ASSERT
+AssertEquals_LREAL(0.99452189536827339586,  H3.GetI(0), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(-0.10452846326765348803, H3.GetI(1), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(0,                       H3.GetI(2), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(9.90698359714502437,     H3.GetI(3), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(0.10452846326765348803,  H3.GetI(4), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(0.99452189536827339586,  H3.GetI(5), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(0,                       H3.GetI(6), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(-0.344448637286709158,   H3.GetI(7), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(0,                       H3.GetI(8), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(0,                       H3.GetI(9), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(1,                       H3.GetI(10), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(5.15,                    H3.GetI(11), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(0,                       H3.GetI(12), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(0,                       H3.GetI(13), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(0,                       H3.GetI(14), Delta, 'H1*H2 is not correct');
+AssertEquals_LREAL(1,                       H3.GetI(15), Delta, 'H1*H2 is not correct');
+
+TEST_FINISHED();
+]]></ST>
       </Implementation>
     </Method>
     <Method Name="WhenSetFromComponentsExpectValuesRetained" Id="{09201a71-edee-42bf-896b-1afd1555a103}">

--- a/TcTransformTest/TcTransformTest/TESTs/FB_RMatrix_Test.TcPOU
+++ b/TcTransformTest/TcTransformTest/TESTs/FB_RMatrix_Test.TcPOU
@@ -16,8 +16,49 @@ WhenRotatedTwiceExpectDouble();
 WhenSetFrom321AnglesExpectResult();
 WhenVectorRotatedExpectResult();
 WhenReversedExpectOpposite();
-WhenSetFromVectorsExpectResult();]]></ST>
+WhenSetFromVectorsExpectResult();
+WhenPostMultipliedByRMatrixExpectResult();
     </Implementation>
+    <Method Name="WhenPostMultipliedByRMatrixExpectResult" Id="{bdbe93cc-2d4c-0bb5-2025-727dca69fa9f}">
+      <Declaration><![CDATA[METHOD PRIVATE WhenPostMultipliedByRMatrixExpectResult
+VAR_INPUT
+END_VAR
+VAR
+	R1 : RMatrix;
+	R2 : RMatrix;
+R3 : RMatrix;
+
+    Delta : LREAL := 1E-09;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('WhenPostMultipliedByRMatrixExpectResult');
+
+// @TEST-RUN
+R1.SetFromAngle(-PI/2,0);
+R1.SetFromAngle( PI/2,1);
+R1.SetFromAngle(-PI/4,2);
+R2.SetFromAngle( PI/3,0);
+
+RMatrix_Product(R1, R2, R3);
+
+// @TEST-ASSERT
+AssertEquals_LREAL(0.7071067811865476, R3.GetI(0), Delta, 'R1*R2 is not correct');
+AssertEquals_LREAL(0.35355339059327382071, R3.GetI(1), Delta, 'R1*R2 is not correct');
+AssertEquals_LREAL(-0.61237243569579447035, R3.GetI(2), Delta, 'R1*R2 is not correct');
+AssertEquals_LREAL(-0.7071067811865475, R3.GetI(3), Delta, 'R1*R2 is not correct');
+AssertEquals_LREAL(0.35355339059327387071, R3.GetI(4), Delta, 'R1*R2 is not correct');
+AssertEquals_LREAL(-0.61237243569579455695, R3.GetI(5), Delta, 'R1*R2 is not correct');
+AssertEquals_LREAL(0, R3.GetI(6), Delta, 'R1*R2 is not correct');
+AssertEquals_LREAL(0.8660254037844386, R3.GetI(7), Delta, 'R1*R2 is not correct');
+AssertEquals_LREAL(0.5000000000000001, R3.GetI(8), Delta, 'R1*R2 is not correct');
+
+TEST_FINISHED();]]></ST>
+      </Implementation>
+    </Method>
+TEST_FINISHED();]]></ST>
+      </Implementation>
+    </Method>
     <Method Name="WhenReversedExpectOpposite" Id="{e47eb044-1085-4952-9808-e96e8cc7d353}">
       <Declaration><![CDATA[METHOD PRIVATE WhenReversedExpectOpposite
 VAR_INPUT

--- a/TcTransformTest/TcTransformTest/TESTs/FB_RMatrix_Test.TcPOU
+++ b/TcTransformTest/TcTransformTest/TESTs/FB_RMatrix_Test.TcPOU
@@ -18,6 +18,7 @@ WhenVectorRotatedExpectResult();
 WhenReversedExpectOpposite();
 WhenSetFromVectorsExpectResult();
 WhenPostMultipliedByRMatrixExpectResult();
+WhenPostMultipliedByVector3ExpectResult();]]></ST>
     </Implementation>
     <Method Name="WhenPostMultipliedByRMatrixExpectResult" Id="{bdbe93cc-2d4c-0bb5-2025-727dca69fa9f}">
       <Declaration><![CDATA[METHOD PRIVATE WhenPostMultipliedByRMatrixExpectResult
@@ -56,6 +57,37 @@ AssertEquals_LREAL(0.5000000000000001, R3.GetI(8), Delta, 'R1*R2 is not correct'
 TEST_FINISHED();]]></ST>
       </Implementation>
     </Method>
+    <Method Name="WhenPostMultipliedByVector3ExpectResult" Id="{ae31952a-f0a4-0385-2777-6375b894da5d}">
+      <Declaration><![CDATA[METHOD PRIVATE WhenPostMultipliedByVector3ExpectResult
+VAR_INPUT
+END_VAR
+VAR
+	R1 : RMatrix;
+	V1 : Vector3;
+    VRes : Vector3;
+
+    Delta : LREAL := 1E-09;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('WhenPostMultipliedByVector3ExpectResult');
+
+// @TEST-RUN
+R1.SetFromAngle(-PI/2,0);
+R1.SetFromAngle( PI/2,1);
+R1.SetFromAngle(-PI/4,2);
+
+V1.SetI(0, -3);
+V1.SetI(1, 7.5);
+V1.SetI(2, -0.6);
+
+RMatrix_Vector3_Product(R1, V1, VRes);
+
+// @TEST-ASSERT
+AssertEquals_LREAL(3.18198051533946345, VRes.GetI(0), Delta, 'R1*V1 is not correct');
+AssertEquals_LREAL(7.4246212024587495, VRes.GetI(1), Delta, 'R1*V1 is not correct');
+AssertEquals_LREAL(-0.6, VRes.GetI(2), Delta, 'R1*V1 is not correct');
+
 TEST_FINISHED();]]></ST>
       </Implementation>
     </Method>


### PR DESCRIPTION
Added some alternatives to the general purpose `Matrix_Product` function. These alternatives are much faster as they don't need multiple checks. The HMatrix_Product is also optimized. I think that the codesys compiler is not optimizing during compiling, so removing branches and reading from memory directly instead of using the `GetI` or `GetRC` helps a lot. You can see the discussion on this optimization here https://github.com/stefanbesler/twingrind/issues/12.

| Function name           | Multiplication    |
|-------------------------|-------------------|
| RMatrix_Product         | RMatrix * RMatrix |
| RMatrix_Vector3_Product | RMatrix * Vector3 |
| HMatrix_Product         | HMatrix * HMatrix |